### PR TITLE
Add note to avoid publish failure for first-timers

### DIFF
--- a/index.md
+++ b/index.md
@@ -96,6 +96,8 @@ For more info about the crates.io tokens, see
 
 ### Publish
 
+If this is your first ever crate, [ensure your email address is verified on crates.io](https://crates.io/settings/profile) before you publish.
+
 When you are ready to publish the first version of your application, run:
 
 ```sh


### PR DESCRIPTION
I encountered a publish failure on my first attempt, because I'd logged into crates.io via GitHub.

This PR simply adds a note to check for that before you publish, so that 0.1.0 release doesn't fail.

___

*Unrelated to the pr, but needs saying: Thanks for this template, @maintainers, it's utterly awesome. Even the python ecosystem doesn't have cookiecutters this powerful. I can't believe all the github actions work out of the box!!!!*